### PR TITLE
Refactor to psutil flags

### DIFF
--- a/pg_view/__init__.py
+++ b/pg_view/__init__.py
@@ -11,6 +11,7 @@ from multiprocessing import JoinableQueue  # for then number of cpus
 from optparse import OptionParser
 
 from pg_view import consts
+from pg_view import flags
 from pg_view.collectors.host_collector import HostStatCollector
 from pg_view.collectors.memory_collector import MemoryStatCollector
 from pg_view.collectors.partition_collector import PartitionStatCollector, DetachedDiskStatCollector
@@ -91,19 +92,19 @@ def loop(collectors, consumer, groups, output_method):
 def poll_keys(screen, output):
     c = screen.getch()
     if c == ord('u'):
-        consts.display_units = consts.display_units is False
+        flags.display_units = flags.display_units is False
     if c == ord('f'):
-        consts.freeze = consts.freeze is False
+        flags.freeze = flags.freeze is False
     if c == ord('s'):
-        consts.filter_aux = consts.filter_aux is False
+        flags.filter_aux = flags.filter_aux is False
     if c == ord('h'):
         output.toggle_help()
     if c == ord('a'):
-        consts.autohide_fields = consts.autohide_fields is False
+        flags.autohide_fields = flags.autohide_fields is False
     if c == ord('t'):
-        consts.notrim = consts.notrim is False
+        flags.notrim = flags.notrim is False
     if c == ord('r'):
-        consts.realtime = consts.realtime is False
+        flags.realtime = flags.realtime is False
     if c == ord('q'):
         # bail out immediately
         return False
@@ -134,9 +135,9 @@ def do_loop(screen, groups, output_method, collectors, consumer):
                 if not poll_keys(screen, output):
                     # bail out immediately
                     return
-            st.set_units_display(consts.display_units)
-            st.set_ignore_autohide(not consts.autohide_fields)
-            st.set_notrim(consts.notrim)
+            st.set_units_display(flags.display_units)
+            st.set_ignore_autohide(not flags.autohide_fields)
+            st.set_notrim(flags.notrim)
             process_single_collector(st)
             if output_method == OUTPUT_METHOD.curses:
                 if not poll_keys(screen, output):
@@ -153,7 +154,7 @@ def do_loop(screen, groups, output_method, collectors, consumer):
         # in the curses case, refresh shows the data queued by display
         if output_method == OUTPUT_METHOD.curses:
             output.refresh()
-        if not consts.realtime:
+        if not flags.realtime:
             time.sleep(consts.TICK_LENGTH)
 
 

--- a/pg_view/collectors/partition_collector.py
+++ b/pg_view/collectors/partition_collector.py
@@ -5,7 +5,7 @@ import time
 from multiprocessing import Process
 
 from pg_view.collectors.base_collector import StatCollector
-from pg_view.consts import TICK_LENGTH
+from pg_view import consts
 from pg_view.loggers import logger
 from pg_view.models.outputs import COLALIGN
 from pg_view.utils import BLOCK_SIZE
@@ -219,7 +219,7 @@ class DetachedDiskStatCollector(Process):
                 df_data = self.get_df_data(wd)
                 result[wd] = [du_data, df_data]
             self.q.put(result)
-            time.sleep(TICK_LENGTH)
+            time.sleep(consts.TICK_LENGTH)
 
     def get_du_data(self, wd):
         data_size = 0

--- a/pg_view/consts.py
+++ b/pg_view/consts.py
@@ -1,9 +1,1 @@
-# some global variables for keyboard output
-freeze = False
-filter_aux = True
-autohide_fields = False
-display_units = False
-notrim = False
-realtime = False
-
 TICK_LENGTH = 1

--- a/pg_view/flags.py
+++ b/pg_view/flags.py
@@ -1,0 +1,7 @@
+# global user-changable flags to control behavior of pg_view
+freeze = False
+filter_aux = True
+autohide_fields = False
+display_units = False
+notrim = False
+realtime = False

--- a/pg_view/loggers.py
+++ b/pg_view/loggers.py
@@ -1,12 +1,10 @@
 import logging
 
 logger = logging.getLogger(__name__)
+_log_stderr = logging.StreamHandler()
 
+def enable_logging_to_stderr():
+    logger.addHandler(_log_stderr)
 
-def setup_loggers(options):
-    global logger
-
-    logger.setLevel((logging.INFO if options.verbose else logging.ERROR))
-    log_stderr = logging.StreamHandler()
-    logger.addHandler(log_stderr)
-    return log_stderr
+def disable_logging_to_stderr():
+    logger.removeHandler(_log_stderr)

--- a/pg_view/models/outputs.py
+++ b/pg_view/models/outputs.py
@@ -5,7 +5,7 @@ import time
 from collections import namedtuple
 from operator import itemgetter
 
-from pg_view import consts
+from pg_view import flags
 from pg_view.meta import __appname__, __version__, __license__
 
 from pg_view.utils import enum
@@ -157,12 +157,12 @@ class CursesOutput(object):
             pass
 
         menu_items = (
-            ('s', 'system', not consts.filter_aux),
-            ('f', 'freeze', consts.freeze),
-            ('u', 'units', consts.display_units),
-            ('a', 'autohide', consts.autohide_fields),
-            ('t', 'trimming', consts.notrim),
-            ('r', 'realtime', consts.realtime),
+            ('s', 'system', not flags.filter_aux),
+            ('f', 'freeze', flags.freeze),
+            ('u', 'units', flags.display_units),
+            ('a', 'autohide', flags.autohide_fields),
+            ('t', 'trimming', flags.notrim),
+            ('r', 'realtime', flags.realtime),
             ('h', 'help', self.show_help),
         )
 

--- a/pg_view/models/outputs.py
+++ b/pg_view/models/outputs.py
@@ -6,12 +6,9 @@ from collections import namedtuple
 from operator import itemgetter
 
 from pg_view import consts
-from pg_view.utils import enum
+from pg_view.meta import __appname__, __version__, __license__
 
-__appname__ = 'pg_view'
-__version__ = '1.3.1'
-__author__ = 'Oleksii Kliukin <oleksii.kliukin@zalando.de>'
-__license__ = 'Apache 2.0'
+from pg_view.utils import enum
 
 
 COLSTATUS = enum(cs_ok=0, cs_warning=1, cs_critical=2)

--- a/pg_view/utils.py
+++ b/pg_view/utils.py
@@ -2,7 +2,7 @@ import re
 import resource
 import sys
 
-from pg_view.consts import filter_aux, freeze
+from pg_view import flags
 from pg_view.loggers import logger
 
 if sys.hexversion >= 0x03000000:
@@ -75,9 +75,9 @@ def process_single_collector(st):
     """
     from pg_view.collectors.pg_collector import PgstatCollector
     if isinstance(st, PgstatCollector):
-        st.set_aux_processes_filter(filter_aux)
+        st.set_aux_processes_filter(flags.filter_aux)
     st.tick()
-    if not freeze:
+    if not flags.freeze:
         if st.needs_refresh():
             st.refresh()
         if st.needs_diffs():


### PR DESCRIPTION
Move UI flags out of consts, import them properly.

    - move UI flags to a separate module, as they are not constant.
    - fix the issue of not being able to toggle freeze or auxilliary
      processes display as those flags were imported improperly
      (see http://stackoverflow.com/questions/3536620/how-to-change-a-module-variable-from-another-module)